### PR TITLE
Fix scanner bug and clean up UI code

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,15 +1,13 @@
 use tauri::State;
 
-use crate::{audio::PlayerController, library::Library};
+use crate::audio::PlayerController;
 
 #[tauri::command]
 pub async fn play_audio(
     path: String,
     controller: State<'_, PlayerController>,
-    library: State<'_, Library>,
 ) -> Result<(), String> {
     let result = controller.play_now(path);
-    let a = library.scan("/Users/pedrovietro/Downloads").await;
     convert_anyhow_result(result)
 }
 

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -60,12 +60,12 @@ async fn is_audio_file(path: &str) -> anyhow::Result<bool> {
         return Ok(false);
     };
     let mut buf = [0u8; 16];
-    let magic_number_bytes_result = file.read_exact(&mut buf).await;
-    let Ok(magic_number_bytes) = magic_number_bytes_result else {
-        return Ok(false);
+    let bytes_read = match file.read(&mut buf).await {
+        Ok(n) => n,
+        Err(_) => return Ok(false),
     };
     Ok(matches!(
-        infer::get(&buf[..magic_number_bytes]),
+        infer::get(&buf[..bytes_read]),
         Some(kind) if kind.mime_type().starts_with("audio/")
     ))
 }

--- a/src/lib/backend/playerService.ts
+++ b/src/lib/backend/playerService.ts
@@ -1,20 +1,26 @@
 import { listen } from '@tauri-apps/api/event';
 import { writable } from 'svelte/store';
 
-const eventBus = writable(null);
+export interface PlayerEvent {
+	percentage?: number;
+	playedSecs?: number;
+	totalDurationSecs?: number;
+	volume?: number;
+}
 
-function dispatchEvent(event: any) {
+const eventBus = writable<PlayerEvent | null>(null);
+
+function dispatchEvent(event: PlayerEvent) {
 	eventBus.set(event);
 }
 
 // Function to subscribe to the event bus
-export function subscribeToEventBus(callback: (event: any) => void) {
+export function subscribeToEventBus(callback: (event: PlayerEvent | null) => void) {
 	return eventBus.subscribe(callback);
 }
 
 export async function listenToServer() {
-	let tickCount = 0;
 	await listen('player:tick', (event) => {
-		dispatchEvent(event.payload);
+		dispatchEvent(event.payload as PlayerEvent);
 	});
 }

--- a/src/lib/components/player/PlayerBar.svelte
+++ b/src/lib/components/player/PlayerBar.svelte
@@ -7,11 +7,9 @@
 
 	let progressBar: ProgressBar | null = null;
 	let progress = 0;
-	let current = 0;
 	let total = 0;
 	const unsubscribe = subscribeToEventBus((event) => {
 		progress = (event?.percentage ?? 0) * 100;
-		current = event?.playedSecs;
 		total = event?.totalDurationSecs;
 		if (progressBar == null) return;
 		progressBar.setProgress(progress);
@@ -35,7 +33,7 @@
 </script>
 
 <div
-	class="w-full bg-amptree-surface h-20 border-t border-amptree-border flex justify-center items-center"
+	class="flex h-20 w-full items-center justify-center border-t border-amptree-border bg-amptree-surface"
 >
 	<div class="w-1/2">
 		<ProgressBar bind:this={progressBar} on:change={handleSeek} />

--- a/src/lib/components/player/ProgressBar.svelte
+++ b/src/lib/components/player/ProgressBar.svelte
@@ -47,7 +47,7 @@
 	<!-- Hidden range input -->
 
 	<!-- Progress bar container -->
-	<div class="flex items-center justify-items-center h-3 border-none">
+	<div class="flex h-3 items-center justify-items-center border-none">
 		<input
 			type="range"
 			{min}

--- a/src/routes/PlayAudio.svelte
+++ b/src/routes/PlayAudio.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { invoke } from '@tauri-apps/api/core';
 	import { playAudio, pause, resume, seek, queue, skip } from '../lib/backend/commands';
-	let errorMessage: String | null;
+	let errorMessage: string | null = null;
 	const path = '/Users/pedrovietro/Downloads/sample3.flac';
 
 	const doPlayAudio = () => {
@@ -10,18 +9,18 @@
 		});
 	};
 	const doPause = () => {
-		invoke('pause', { path }).catch((err: string) => {
+		pause().catch((err: string) => {
 			errorMessage = err;
 		});
 	};
 	const doResume = () => {
-		invoke('resume', { path }).catch((err: string) => {
+		resume().catch((err: string) => {
 			errorMessage = err;
 		});
 	};
 
 	const doSeek = (seconds: number) => {
-		invoke('seek', { seconds }).catch((err: string) => {
+		seek(seconds).catch((err: string) => {
 			errorMessage = err;
 		});
 	};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,6 @@ export default {
 			colors: {
 				['amptree-bg']: '#2d2d2d',
 				['amptree-surface']: '#403e3e',
-				['amptree-bg']: '#2d2d2d',
 				['amptree-text']: '#ffffff',
 				['amptree-accent']: '#4db8ff',
 				['amptree-secondary-text']: '#b0b0b0',


### PR DESCRIPTION
## Summary
- remove unused library scan and path from `play_audio` command
- fix `is_audio_file` to use `read` and check bytes read
- type playerService events and clean up tick listener
- remove unused variable in PlayerBar
- use backend wrappers in PlayAudio example
- deduplicate color config in Tailwind
- reformat Svelte components

## Testing
- `npm run lint`
- `cargo test` *(fails: system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e960eecc8330a09efe55a73cb05c